### PR TITLE
Fix GeoServer plugin for GeoGig 1.0-RC2

### DIFF
--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/ImportRepositoryFormBean.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/ImportRepositoryFormBean.java
@@ -1,0 +1,42 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geogig.geoserver.config;
+
+/**
+ * Bean object to make importing existing repositories easier. Importing an existing GeoGig repo
+ * will either consist of a Repository Name AND a {@link PostgresConfigBean}, OR just a single
+ * Repository directory.
+ */
+public class ImportRepositoryFormBean {
+
+    private String repoName;
+    private String repoDirectory;
+    private PostgresConfigBean pgBean = new PostgresConfigBean();
+
+    public String getRepoName() {
+        return repoName;
+    }
+
+    public void setRepoName(String repoName) {
+        this.repoName = repoName;
+    }
+
+    public String getRepoDirectory() {
+        return repoDirectory;
+    }
+
+    public void setRepoDirectory(String repoDirectory) {
+        this.repoDirectory = repoDirectory;
+    }
+
+    public PostgresConfigBean getPgBean() {
+        return pgBean;
+    }
+
+    public void setPgBean(PostgresConfigBean pgBean) {
+        this.pgBean = pgBean;
+    }
+
+}

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/PostgresConfigBean.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/PostgresConfigBean.java
@@ -80,7 +80,7 @@ public class PostgresConfigBean implements Serializable {
         this.port = port;
     }
 
-    public URI toUri(String repoId) {
+    public URI buildUriForRepo(String repoId) {
         StringBuilder sb = new StringBuilder(128);
         sb.append(SCHEME).append(this.host);
         if (port > 0) {
@@ -103,8 +103,10 @@ public class PostgresConfigBean implements Serializable {
     public static PostgresConfigBean from(URI location) {
         Preconditions.checkNotNull(location, "Cannot parse NULL URI location");
         Preconditions.checkNotNull(location.getScheme(), "Cannot parse NULL URI scheme");
-        Preconditions.checkArgument("postgresql".equals(location.getScheme()),
-                "Cannot parse non-postgresql URI schem");
+        if (!"postgresql".equals(location.getScheme())) {
+            // don't parse, return new object
+            return newInstance();
+        }
         // build a bean from the parts
         String host = location.getHost();
         int port = location.getPort();

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryManager.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryManager.java
@@ -31,6 +31,7 @@ import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.web.GeoServerApplication;
 import org.locationtech.geogig.api.Context;
 import org.locationtech.geogig.api.ContextBuilder;
+import org.locationtech.geogig.api.DefaultPlatform;
 import org.locationtech.geogig.api.GeoGIG;
 import org.locationtech.geogig.api.GlobalContextBuilder;
 import org.locationtech.geogig.api.Ref;

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/model/DropDownModel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/model/DropDownModel.java
@@ -1,0 +1,78 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geogig.geoserver.model;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.wicket.model.IModel;
+import org.geogig.geoserver.config.RepositoryInfo;
+
+/**
+ * Data model for the drop-down choice for GeoGig repository configuration. Currently, either a
+ * Directory backend or a PostgreSQL backend are supported.
+ */
+public class DropDownModel implements IModel<Serializable> {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String PG_CONFIG = "PostgreSQL";
+    public static final String DIRECTORY_CONFIG = "Directory";
+    public static final String DEFAULT_CONFIG = DIRECTORY_CONFIG;
+    public static final List<String> CONFIG_LIST = Arrays.asList(DropDownModel.DIRECTORY_CONFIG,
+            DropDownModel.PG_CONFIG);
+
+    private final IModel<RepositoryInfo> repoModel;
+    private String type;
+
+    public DropDownModel(IModel<RepositoryInfo> repoModel) {
+        this.repoModel = repoModel;
+        if (null == repoModel || null == repoModel.getObject() || null == repoModel.getObject()
+                .getLocation()) {
+            type = DEFAULT_CONFIG;
+        }
+    }
+
+    @Override
+    public Serializable getObject() {
+        if (type == null) {
+            // get the type from the model
+            RepositoryInfo repo = repoModel.getObject();
+            URI location = repo != null ? repo.getLocation() : null;
+            if (location != null) {
+                if (null != location.getScheme()) {
+                    switch (location.getScheme()) {
+                        case "postgresql":
+                            type = PG_CONFIG;
+                            break;
+                        case "file":
+                            type = DIRECTORY_CONFIG;
+                            break;
+                        default:
+                            type = DEFAULT_CONFIG;
+                            break;
+                    }
+                }
+            }
+        }
+        return type;
+    }
+
+    @Override
+    public void setObject(Serializable object) {
+        type = object.toString();
+    }
+
+    @Override
+    public void detach() {
+        if (repoModel != null) {
+            repoModel.detach();
+        }
+        type = null;
+    }
+
+}

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/model/ImportRepositoryFormModel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/model/ImportRepositoryFormModel.java
@@ -1,0 +1,69 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geogig.geoserver.model;
+
+import java.net.URI;
+
+import org.apache.wicket.model.IModel;
+import org.geogig.geoserver.config.ImportRepositoryFormBean;
+import org.geogig.geoserver.config.PostgresConfigBean;
+import org.geogig.geoserver.config.RepositoryInfo;
+
+/**
+ * Data model for importing an existing GeoGig repository. This model essentially wraps a
+ * {@link RepositoryInfo} and uses {@link ImportRepositoryFormBean} to hold the UI pieces that are
+ * used to construct the repository location {@link java.net.URI}.
+ */
+public class ImportRepositoryFormModel implements IModel<ImportRepositoryFormBean> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final IModel<RepositoryInfo> repoInfoModel;
+    private ImportRepositoryFormBean bean;
+
+    public ImportRepositoryFormModel(IModel<RepositoryInfo> repoInfoModel) {
+        this.repoInfoModel = repoInfoModel;
+    }
+
+    @Override
+    public ImportRepositoryFormBean getObject() {
+        if (bean == null) {
+            bean = new ImportRepositoryFormBean();
+            RepositoryInfo repoInfo = repoInfoModel.getObject();
+            if (repoInfo != null && repoInfo.getLocation() != null) {
+                final URI uri = repoInfo.getLocation();
+                // get the scheme
+                final String scheme = uri.getScheme();
+                final String path = uri.getPath();
+                switch (scheme) {
+                    case "file":
+                        // parse the driectroy out of the path
+                        bean.setRepoDirectory(path);
+                    case "postgresql":
+                        // build the pgBean
+                        bean.setPgBean(PostgresConfigBean.from(uri));
+                        // get the name
+                        final String repoName = repoInfo.getRepoName();
+                        bean.setRepoName(repoName);
+                }
+            }
+        }
+        return bean;
+    }
+
+    @Override
+    public void setObject(ImportRepositoryFormBean object) {
+        this.bean = object;
+    }
+
+    @Override
+    public void detach() {
+        if (repoInfoModel != null) {
+            repoInfoModel.detach();
+        }
+        bean = null;
+    }
+
+}

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/model/PGBeanModel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/model/PGBeanModel.java
@@ -17,6 +17,8 @@ import org.geogig.geoserver.config.RepositoryInfo;
  */
 public class PGBeanModel implements IModel<PostgresConfigBean> {
 
+    private static final long serialVersionUID = 1L;
+
     private final IModel<RepositoryInfo> repoModel;
     private PostgresConfigBean bean;
 

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/model/RepoDirModel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/model/RepoDirModel.java
@@ -19,6 +19,8 @@ import org.geogig.geoserver.config.RepositoryInfo;
  */
 public class RepoDirModel implements IModel<String> {
 
+    private static final long serialVersionUID = 1L;
+
     private final IModel<RepositoryInfo> repoModel;
     private String parentDirectory;
 

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/model/RepoNameModel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/model/RepoNameModel.java
@@ -14,6 +14,8 @@ import org.geogig.geoserver.config.RepositoryInfo;
  */
 public class RepoNameModel implements IModel<String> {
 
+    private static final long serialVersionUID = 1L;
+
     private final IModel<RepositoryInfo> repoModel;
     private String repoName;
 

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/util/PostgresConnectionErrorHandler.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/util/PostgresConnectionErrorHandler.java
@@ -1,0 +1,43 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geogig.geoserver.util;
+
+import java.net.UnknownHostException;
+
+import org.postgresql.util.PSQLException;
+
+/**
+ * Utility class for building the best error message for PostgreSQL connection errors.
+ */
+public class PostgresConnectionErrorHandler {
+
+    public static String getMessage(final Throwable t) {
+        // grab the localized message for the source Throwable. If there or no other causes in the
+        // stack, use the top-most message.
+        String message = t.getLocalizedMessage();
+        // flag indicating if we've uncovered a cause that is an instance of
+        // org.postgresql.util.PSQLException.
+        boolean psqlCauseFound = false;
+        // start digging
+        Throwable cause = t;
+        while (cause != null) {
+            // Get the type of the Throwable
+            Class clazz = cause.getClass();
+            // If we have an UnknownHostException, we're done
+            if (UnknownHostException.class.isAssignableFrom(clazz)) {
+                return "UnknownHostException: " + cause.getLocalizedMessage();
+            }
+            // if we haven't already found a PSQLException, see if this cause is one.
+            if (!psqlCauseFound && PSQLException.class.isAssignableFrom(clazz)) {
+                // it's a PSQLException, and it's the first one found
+                psqlCauseFound = true;
+                message = cause.getLocalizedMessage();
+            }
+            // get the next cause
+            cause = cause.getCause();
+        }
+        return message;
+    }
+}

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/RepositoriesPage.html
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/RepositoriesPage.html
@@ -1,23 +1,16 @@
 <html xmlns:wicket="http://wicket.apache.org/">
-<head>
-<title><wicket:message key="title">Repositories</wicket:message></title>
-</head>
-<body>
-<wicket:extend>
-	<div wicket:id="table"></div>
-    
+  <head>
+    <title><wicket:message key="title">Repositories</wicket:message></title>
+  </head>
+  <body>
+  <wicket:extend>
+    <div wicket:id="table"></div>
     <wicket:fragment wicket:id="header">
       <ul>
-        <li>
-        	<form wicket:id="chooseRepoForm">
-        		<a class="add-link" href="#" wicket:id="importExisting"><wicket:message key="importExisting"/></a>
-        	</form>
-        </li>
+        <li><a class="add-link" href="#" wicket:id="importExisting"><wicket:message key="importExisting" /></a></li>
         <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
       </ul>
     </wicket:fragment>
-    
-    <div wicket:id="modalWindow"></div>
-</wicket:extend>
+  </wicket:extend>
 </body>
 </html>

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/RepositoriesPage.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/RepositoriesPage.java
@@ -4,21 +4,9 @@
  */
 package org.geogig.geoserver.web;
 
-import java.io.File;
-
 import org.apache.wicket.Component;
-import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.form.AjaxSubmitLink;
-import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
-import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 import org.apache.wicket.markup.html.panel.Fragment;
-import org.apache.wicket.model.IModel;
-import org.apache.wicket.model.Model;
-import org.apache.wicket.model.ResourceModel;
-import org.geogig.geoserver.config.RepositoryInfo;
-import org.geogig.geoserver.config.RepositoryManager;
-import org.geogig.geoserver.web.repository.DirectoryChooser;
 import org.geogig.geoserver.web.repository.RepositoriesListPanel;
 import org.geoserver.web.GeoServerSecuredPage;
 
@@ -26,8 +14,6 @@ import org.geoserver.web.GeoServerSecuredPage;
  * Add/edit/remove repositories
  */
 public class RepositoriesPage extends GeoServerSecuredPage {
-
-    private final ModalWindow repoChooserWindow;
 
     private final RepositoriesListPanel table;
 
@@ -37,66 +23,15 @@ public class RepositoriesPage extends GeoServerSecuredPage {
         table.setOutputMarkupId(true);
         add(table);
 
-        // add the dialog for the repository chooser
-        add(repoChooserWindow = new ModalWindow("modalWindow"));
-
         setHeaderPanel(headerPanel());
     }
 
     protected Component headerPanel() {
         Fragment header = new Fragment(HEADER_PANEL, "header", this);
 
-        IModel<RepositoryInfo> newInfo = new Model<RepositoryInfo>(new RepositoryInfo());
-        Form<RepositoryInfo> chooseRepoForm = new Form<RepositoryInfo>("chooseRepoForm", newInfo);
-        chooseRepoForm.add(chooserButton(chooseRepoForm));
-        header.add(chooseRepoForm);
-
+        header.add(new BookmarkablePageLink<String>("importExisting", RepositoryImportPage.class));
         header.add(new BookmarkablePageLink<String>("addNew", RepositoryEditPage.class));
 
         return header;
-    }
-
-    protected Component chooserButton(Form<RepositoryInfo> form) {
-        AjaxSubmitLink link = new AjaxSubmitLink("importExisting", form) {
-
-            private static final long serialVersionUID = 1242472443848716943L;
-
-            @Override
-            public boolean getDefaultFormProcessing() {
-                return false;
-            }
-
-            @Override
-            public void onSubmit(AjaxRequestTarget target, Form<?> form) {
-                DirectoryChooser chooser;
-                chooser = new DirectoryChooser(repoChooserWindow.getContentId(), new Model<File>()) {
-
-                    private static final long serialVersionUID = 1L;
-
-                    @Override
-                    protected void geogigDirectoryClicked(final File file, AjaxRequestTarget target) {
-                        // clear the raw input of the field won't show the new model value
-                        RepositoryManager manager = RepositoryManager.get();
-                        RepositoryInfo info = new RepositoryInfo();
-                        info.setLocation(file.getAbsoluteFile().toURI());
-                        manager.save(info);
-                        repoChooserWindow.close(target);
-                        target.addComponent(table);
-                    };
-
-                    @Override
-                    protected void directoryClicked(File file, AjaxRequestTarget target) {
-                        super.directoryClicked(file, target);
-                    }
-                };
-                chooser.setFileTableHeight(null);
-                repoChooserWindow.setContent(chooser);
-                repoChooserWindow.setTitle(new ResourceModel(
-                        "GeoGigDirectoryFormComponent.chooser.browseTitle"));
-                repoChooserWindow.show(target);
-            }
-
-        };
-        return link;
     }
 }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/RepositoryImportPage.html
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/RepositoryImportPage.html
@@ -1,0 +1,10 @@
+<html xmlns:wicket="http://wicket.apache.org/">
+  <head>
+    <title><wicket:message key="title">Repositories</wicket:message></title>
+  </head>
+  <body>
+  <wicket:extend>
+    <div wicket:id="panel"></div>
+  </wicket:extend>
+</body>
+</html>

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/RepositoryImportPage.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/RepositoryImportPage.java
@@ -1,0 +1,45 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geogig.geoserver.web;
+
+import javax.annotation.Nullable;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.model.IModel;
+import org.geogig.geoserver.config.RepositoryInfo;
+import org.geogig.geoserver.web.repository.RepositoryImportFormPanel;
+import org.geoserver.web.GeoServerSecuredPage;
+
+/**
+ * Page object for importing existing GeoGig repositories. This is very similar to
+ * {@link RepositoryEditPage}, but uses a {@link RepositoryImportFormPanel} instead of an edit
+ * panel.
+ */
+public class RepositoryImportPage extends GeoServerSecuredPage {
+
+    private static final long serialVersionUID = 1L;
+
+    public RepositoryImportPage() {
+        this(null);
+    }
+
+    public RepositoryImportPage(@Nullable IModel<RepositoryInfo> repoInfo) {
+        super();
+        add(new RepositoryImportFormPanel("panel", repoInfo) {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            protected void saved(RepositoryInfo info, AjaxRequestTarget target) {
+                setResponsePage(RepositoriesPage.class);
+            }
+
+            @Override
+            protected void cancelled(AjaxRequestTarget target) {
+                setResponsePage(RepositoriesPage.class);
+            }
+        });
+    }
+
+}

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/data/store/geogig/GeoGigDataStoreEditPanel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/data/store/geogig/GeoGigDataStoreEditPanel.java
@@ -8,7 +8,6 @@ import static org.locationtech.geogig.geotools.data.GeoGigDataStoreFactory.BRANC
 import static org.locationtech.geogig.geotools.data.GeoGigDataStoreFactory.REPOSITORY;
 import static org.locationtech.geogig.geotools.data.GeoGigDataStoreFactory.RESOLVER_CLASS_NAME;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -26,14 +25,13 @@ import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.IChoiceRenderer;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
-import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
 import org.geogig.geoserver.config.GeoServerStoreRepositoryResolver;
 import org.geogig.geoserver.config.RepositoryInfo;
 import org.geogig.geoserver.config.RepositoryManager;
-import org.geogig.geoserver.web.repository.DirectoryChooser;
 import org.geogig.geoserver.web.repository.RepositoryEditFormPanel;
+import org.geogig.geoserver.web.repository.RepositoryImportFormPanel;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.web.data.store.DataAccessEditPage;
 import org.geoserver.web.data.store.DataAccessNewPage;
@@ -174,7 +172,7 @@ public class GeoGigDataStoreEditPanel extends StoreEditPanel {
         return link;
     }
 
-    protected Component importExistingLink(Form<DataStoreInfo> storeEditForm) {
+    private Component importExistingLink(Form<DataStoreInfo> storeEditForm) {
 
         AjaxSubmitLink link = new AjaxSubmitLink("importExisting", storeEditForm) {
 
@@ -187,26 +185,25 @@ public class GeoGigDataStoreEditPanel extends StoreEditPanel {
 
             @Override
             public void onSubmit(final AjaxRequestTarget target, final Form<?> form) {
-                DirectoryChooser chooser;
-                chooser = new DirectoryChooser(modalWindow.getContentId(), new Model<File>()) {
-
+                final RepositoryImportFormPanel panel;
+                panel = new RepositoryImportFormPanel(modalWindow.getContentId()) {
                     private static final long serialVersionUID = 1L;
 
                     @SuppressWarnings("unchecked")
                     @Override
-                    protected void geogigDirectoryClicked(final File file,
-                            AjaxRequestTarget target) {
-                        // clear the raw input of the field won't show the new model value
-                        RepositoryManager manager = RepositoryManager.get();
-                        RepositoryInfo info = new RepositoryInfo();
-                        info.setLocation(file.getAbsoluteFile().toURI());
-                        info = manager.save(info);
+                    protected void saved(final RepositoryInfo info,
+                            final AjaxRequestTarget target) {
                         modalWindow.close(target);
                         updateRepository((Form<DataStoreInfo>) form, target, info);
                     }
+
+                    @Override
+                    protected void cancelled(AjaxRequestTarget target) {
+                        modalWindow.close(target);
+                    }
                 };
-                chooser.setFileTableHeight(null);
-                modalWindow.setContent(chooser);
+
+                modalWindow.setContent(panel);
                 modalWindow.setTitle(
                         new ResourceModel("GeoGigDirectoryFormComponent.chooser.browseTitle"));
                 modalWindow.show(target);

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/GeoGigDirectoryFormComponent.html
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/GeoGigDirectoryFormComponent.html
@@ -1,7 +1,7 @@
 <html xmlns:wicket="http://wicket.apache.org/">
 <body>
 <wicket:panel>
-      <span><wicket:message key="directory">bar</wicket:message></span>
+      <label><wicket:message key="directory">bar</wicket:message></label>
       <div wicket:id="wrapper">
         <input class="text" wicket:id="value" type="text"/>
          <a href="#" wicket:id="chooser"><wicket:message key="browse">...</wicket:message></a>

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/GeoGigDirectoryFormComponent.html
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/GeoGigDirectoryFormComponent.html
@@ -1,7 +1,7 @@
 <html xmlns:wicket="http://wicket.apache.org/">
 <body>
 <wicket:panel>
-      <label><wicket:message key="directory">bar</wicket:message></label>
+      <label wicket:id="directoryLabel">bar</label>
       <div wicket:id="wrapper">
         <input class="text" wicket:id="value" type="text"/>
          <a href="#" wicket:id="chooser"><wicket:message key="browse">...</wicket:message></a>

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/GeoGigDirectoryFormComponent.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/GeoGigDirectoryFormComponent.java
@@ -10,6 +10,7 @@ import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.form.AjaxSubmitLink;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
+import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.FormComponentPanel;
 import org.apache.wicket.markup.html.form.TextField;
@@ -33,9 +34,9 @@ class GeoGigDirectoryFormComponent extends FormComponentPanel<String> {
     private final ModalWindow dialog;
 
     /**
-     * 
+     *
      * @param validators any extra validator that should be added to the input field, or
-     *        {@code null}
+     *                   {@code null}
      */
     public GeoGigDirectoryFormComponent(final String id, final IModel<String> valueModel) {
         // make the value of the text field the model of this panel, for easy value retrieval
@@ -45,11 +46,19 @@ class GeoGigDirectoryFormComponent extends FormComponentPanel<String> {
         add(dialog = new ModalWindow("dialog"));
 
         // the text field, with a decorator for validations
-        directory = new TextField<String>("value", valueModel);
+        directory = new TextField<>("value", valueModel);
         directory.setRequired(true);
         directory.setOutputMarkupId(true);
-        directory.setLabel(new ResourceModel("directory", "Parent directory"));
-        // directory.add(GEOGIG_DIR_VALIDATOR);
+
+        final Label directoryLabel = new Label("directoryLabel", new ResourceModel("directory",
+                "Parent directory") {
+            @Override
+            public String getObject() {
+                String value = super.getObject();
+                return value + " *";
+            }
+        }.getObject());
+        add(directoryLabel);
 
         FormComponentFeedbackBorder feedback = new FormComponentFeedbackBorder("wrapper");
         feedback.add(directory);
@@ -84,7 +93,7 @@ class GeoGigDirectoryFormComponent extends FormComponentPanel<String> {
 
                 final boolean makeRepositoriesSelectable = false;
                 DirectoryChooser chooser = new DirectoryChooser(dialog.getContentId(),
-                        new Model<File>(file), makeRepositoriesSelectable) {
+                        new Model<>(file), makeRepositoriesSelectable) {
 
                     private static final long serialVersionUID = 1L;
 

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/GeoGigRepositoryInfoFormComponent.html
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/GeoGigRepositoryInfoFormComponent.html
@@ -1,20 +1,12 @@
 <html xmlns:wicket="http://wicket.apache.org/">
   <body>
   <wicket:panel>
-    <span><wicket:message key="name">name</wicket:message></span>
-    <div><input class="text" wicket:id="repositoryName" type="text"/></div>
+    <div wicket:id=repositoryNamePanel">repositoryNamePanel</div>
     <ul>
-      <li>
-      <wicket:message key="configChoice">PG Config</wicket:message>
-      <div><select name="configChoice" wicket:id="configChoice"/></div>
-      </li>
+      <li wicket:id="configChoicePanel">configChoicePanel</li>
       <div wicket:id="settingsContainer">
-        <li>
-          <div wicket:id="parentDirectory"></div>
-        </li>
-        <li>
-          <div wicket:id="pgPanel"></div>
-        </li>
+        <li wicket:id="parentDirectory">parentDirectory</li>
+        <li wicket:id="pgPanel">pgPanel</li>
       </div>
     </ul>
   </wicket:panel>

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/GeoGigRepositoryInfoFormComponent.html
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/GeoGigRepositoryInfoFormComponent.html
@@ -1,10 +1,10 @@
 <html xmlns:wicket="http://wicket.apache.org/">
   <body>
   <wicket:panel>
-    <div wicket:id=repositoryNamePanel">repositoryNamePanel</div>
     <ul>
       <li wicket:id="configChoicePanel">configChoicePanel</li>
       <div wicket:id="settingsContainer">
+        <li wicket:id=repositoryNamePanel">repositoryNamePanel</li>
         <li wicket:id="parentDirectory">parentDirectory</li>
         <li wicket:id="pgPanel">pgPanel</li>
       </div>

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/GeoGigRepositoryInfoFormComponent.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/GeoGigRepositoryInfoFormComponent.java
@@ -4,6 +4,7 @@
  */
 package org.geogig.geoserver.web.repository;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -15,13 +16,15 @@ import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.FormComponentPanel;
-import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.ResourceModel;
 import org.geogig.geoserver.config.PostgresConfigBean;
 import org.geogig.geoserver.config.RepositoryInfo;
 import org.geogig.geoserver.model.PGBeanModel;
 import org.geogig.geoserver.model.RepoDirModel;
 import org.geogig.geoserver.model.RepoNameModel;
+import org.geoserver.web.data.store.panel.DropDownChoiceParamPanel;
+import org.geoserver.web.data.store.panel.TextParamPanel;
 
 /**
  * Wicket form panel to hold form components for configuring a GeoGig repository. This panel allows
@@ -36,13 +39,13 @@ class GeoGigRepositoryInfoFormComponent extends FormComponentPanel<RepositoryInf
 
     private static final long serialVersionUID = 1L;
 
-    static final String FILE_CONFIG = "File";
+    static final String DIRECTORY_CONFIG = "Directory";
     static final String PG_CONFIG = "PostgreSQL";
-    static final String DEFAULT_CONFIG = FILE_CONFIG;
-    static final List<String> CONFIG_LIST = Arrays.asList(FILE_CONFIG, PG_CONFIG);
+    static final String DEFAULT_CONFIG = DIRECTORY_CONFIG;
+    static final List<String> CONFIG_LIST = Arrays.asList(DIRECTORY_CONFIG, PG_CONFIG);
 
-    private final TextField<String> name;
-    private final DropDownChoice<String> dropdown;
+    private final TextParamPanel repoNamePanel;
+    private final DropDownChoiceParamPanel dropdownPanel;
     private final GeoGigDirectoryFormComponent directoryComponent;
     private final PostgresConfigFormPanel pgPanel;
 
@@ -51,45 +54,41 @@ class GeoGigRepositoryInfoFormComponent extends FormComponentPanel<RepositoryInf
     public GeoGigRepositoryInfoFormComponent(String id, IModel<RepositoryInfo> model) {
         super(id, model);
 
-        RepositoryInfo repoInfo = model.getObject();
-
         IModel<String> nameModel = new RepoNameModel(model);
-        name = new TextField<>("repositoryName", nameModel);
-        name.setRequired(true);
-        //name.setLabel(new ResourceModel("name", "Repo name"));
-        if (repoInfo.getRepoName() != null) {
-            name.setModelObject(repoInfo.getRepoName());
-        }
-        add(name);
+        repoNamePanel = new TextParamPanel("repositoryNamePanel", nameModel,
+                new ResourceModel("GeoGigRepositoryInfoFormComponent.repositoryName",
+                        "Repository Name"), true);
+        add(repoNamePanel);
 
         // add the dropdown to switch between configurations
-        dropdown = new DropDownChoice<>("configChoice", new DropDownModel(model), CONFIG_LIST);
-        dropdown.add(new AjaxFormComponentUpdatingBehavior("onChange") {
+        dropdownPanel = new DropDownChoiceParamPanel("configChoicePanel", new DropDownModel(model),
+                new ResourceModel("GeoGigRepositoryInfoFormComponent.repositoryType",
+                        "Repository Type"), CONFIG_LIST, true);
+        final DropDownChoice<Serializable> dropDownChoice = dropdownPanel.getFormComponent();
+        dropDownChoice.add(new AjaxFormComponentUpdatingBehavior("onChange") {
             @Override
             protected void onUpdate(AjaxRequestTarget target) {
-                final String value = dropdown.getModelObject();
-                directoryComponent.setVisible(FILE_CONFIG.equals(value));
+                final String value = dropDownChoice.getModelObject().toString();
+                directoryComponent.setVisible(DIRECTORY_CONFIG.equals(value));
                 pgPanel.setVisible(PG_CONFIG.equals(value));
                 target.addComponent(settingsContainer);
             }
         });
-        dropdown.setOutputMarkupId(true);
-        dropdown.setNullValid(true);
-        dropdown.setRequired(true);
-        add(dropdown);
+        add(dropdownPanel);
 
         settingsContainer = new WebMarkupContainer("settingsContainer");
         settingsContainer.setOutputMarkupId(true);
         add(settingsContainer);
 
         pgPanel = new PostgresConfigFormPanel("pgPanel", new PGBeanModel(model));
-        pgPanel.setVisible(PG_CONFIG.equals(dropdown.getModelObject()));
+        pgPanel.setVisible(PG_CONFIG.equals(dropDownChoice.getModelObject().toString()));
         settingsContainer.add(pgPanel);
 
         directoryComponent = new GeoGigDirectoryFormComponent("parentDirectory",
                 new RepoDirModel(model));
         directoryComponent.setOutputMarkupId(true);
-        directoryComponent.setVisible(FILE_CONFIG.equals(dropdown.getModelObject()));
+        directoryComponent
+                .setVisible(DIRECTORY_CONFIG.equals(dropDownChoice.getModelObject().toString()));
         settingsContainer.add(directoryComponent);
 
     }
@@ -97,38 +96,50 @@ class GeoGigRepositoryInfoFormComponent extends FormComponentPanel<RepositoryInf
     @Override
     protected void convertInput() {
         RepositoryInfo modelObject = getModelObject();
-        final String repoTypeChoice = dropdown.getConvertedInput();
-        if (PG_CONFIG.equals(repoTypeChoice)) {
-            // PG config used
-            PostgresConfigBean bean = pgPanel.getConvertedInput();
-            // build a URI out of the config
-            URI uri = bean.toUri(name.getConvertedInput().trim());
-            modelObject.setLocation(uri);
-        } else if (FILE_CONFIG.equals(repoTypeChoice)) {
-            // local directory used
-            String path = directoryComponent.getConvertedInput().trim();
-            String repoId = name.getConvertedInput().trim();
-            Path uriPath = Paths.get(path, repoId);
-            modelObject.setLocation(uriPath.toUri());
-        } else {
-            throw new IllegalStateException(
-                    String.format("Unknown repositry type '%s', expected one of %s, %s",
-                            repoTypeChoice, PG_CONFIG, FILE_CONFIG));
+        final String repoTypeChoice = dropdownPanel.getFormComponent().getConvertedInput()
+                .toString();
+        if (null != repoTypeChoice) {
+            switch (repoTypeChoice) {
+                case PG_CONFIG:
+                    // PG config used
+                    PostgresConfigBean bean = pgPanel.getConvertedInput();
+                    // build a URI out of the config
+                    URI uri = bean.toUri(repoNamePanel.getFormComponent().getConvertedInput()
+                            .toString().trim());
+                    modelObject.setLocation(uri);
+                    break;
+                case DIRECTORY_CONFIG:
+                    // local directory used
+                    String path = directoryComponent.getConvertedInput().trim();
+                    String repoId = repoNamePanel.getFormComponent().getConvertedInput().toString()
+                            .trim();
+                    Path uriPath = Paths.get(path, repoId);
+                    modelObject.setLocation(uriPath.toUri());
+                    break;
+                default:
+                    throw new IllegalStateException(
+                            String.format("Unknown repositry type '%s', expected one of %s, %s",
+                                    repoTypeChoice, PG_CONFIG, DIRECTORY_CONFIG));
+            }
         }
         setConvertedInput(modelObject);
     }
 
-    class DropDownModel implements IModel<String> {
+    class DropDownModel implements IModel<Serializable> {
 
         private final IModel<RepositoryInfo> repoModel;
         private String type;
 
         public DropDownModel(IModel<RepositoryInfo> repoModel) {
             this.repoModel = repoModel;
+            if (null == repoModel || null == repoModel.getObject() || null == repoModel.getObject()
+                    .getLocation()) {
+                type = DEFAULT_CONFIG;
+            }
         }
 
         @Override
-        public String getObject() {
+        public Serializable getObject() {
             if (type == null) {
                 // get the type from the model
                 RepositoryInfo repo = repoModel.getObject();
@@ -141,7 +152,7 @@ class GeoGigRepositoryInfoFormComponent extends FormComponentPanel<RepositoryInf
                                 type = PG_CONFIG;
                                 break;
                             case "file":
-                                type = FILE_CONFIG;
+                                type = DIRECTORY_CONFIG;
                                 break;
                             default:
                                 type = DEFAULT_CONFIG;
@@ -154,8 +165,8 @@ class GeoGigRepositoryInfoFormComponent extends FormComponentPanel<RepositoryInf
         }
 
         @Override
-        public void setObject(String object) {
-            type = object;
+        public void setObject(Serializable object) {
+            type = object.toString();
         }
 
         @Override

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/PostgresConfigFormPanel.html
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/PostgresConfigFormPanel.html
@@ -2,30 +2,12 @@
   <body>
   <wicket:panel>
     <ul>
-      <li>
-        <span><wicket:message key="host">Host name</wicket:message></span>
-        <div><input id="host" class="field text" type="text" wicket:id="pgHost" /></div>
-      </li>
-      <li>
-        <span><wicket:message key="port">Port Number</wicket:message></span>
-        <div><input id="port" class="field text" type="text" wicket:id="pgPort" /></div>
-      </li>
-      <li>
-        <span><wicket:message key="database">Database Name</wicket:message></span>
-        <div><input id="database" class="field text" type="text" wicket:id="pgDatabase" /></div>
-      </li>
-      <li>
-        <span><wicket:message key="schema">Schema Name</wicket:message></span>
-        <div><input id="schema" class="field text" type="text" wicket:id="pgSchema" /></div>
-      </li>
-      <li>
-        <span><wicket:message key="username">Username</wicket:message></span>
-        <div><input id="username" class="field text" type="text" wicket:id="pgUsername" /></div>
-      </li>
-      <li>
-        <span><wicket:message key="password">Password</wicket:message></span>
-        <div><input id="password" class="field text" type="password" wicket:id="pgPassword" /></div>
-      </li>
+      <li wicket:id="hostPanel">hostPanel</li>
+      <li wicket:id="portPanel">portPanel</li>
+      <li wicket:id="dbPanel">dbPanel</li>
+      <li wicket:id="schemaPanel">schemaPanel</li>
+      <li wicket:id="usernamePanel">usernamPanel</li>
+      <li wicket:id="passwordPanel">oops</li>
     </ul>
   </wicket:panel>
 </body>

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/PostgresConfigFormPanel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/PostgresConfigFormPanel.java
@@ -4,14 +4,15 @@
  */
 package org.geogig.geoserver.web.repository;
 
-import org.geogig.geoserver.config.PostgresConfigBean;
 import org.apache.wicket.markup.html.form.FormComponentPanel;
-import org.apache.wicket.markup.html.form.PasswordTextField;
-import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.validation.validator.MaximumValidator;
 import org.apache.wicket.validation.validator.MinimumValidator;
+import org.geogig.geoserver.config.PostgresConfigBean;
+import org.geoserver.web.data.store.panel.PasswordParamPanel;
+import org.geoserver.web.data.store.panel.TextParamPanel;
 
 /**
  *
@@ -20,35 +21,40 @@ class PostgresConfigFormPanel extends FormComponentPanel<PostgresConfigBean> {
 
     private static final long serialVersionUID = 1L;
 
-    private final TextField<String> hostField;
-    private final TextField<Integer> portField;
-    private final TextField<String> dbField;
-    private final TextField<String> schemaField;
-    private final TextField<String> usernameField;
-    private final PasswordTextField passwordField;
+    private final TextParamPanel hostPanel;
+    private final TextParamPanel portPanel;
+    private final TextParamPanel dbPanel;
+    private final TextParamPanel schemaPanel;
+    private final TextParamPanel usernamePanel;
+    private final PasswordParamPanel passwordPanel;
 
     public PostgresConfigFormPanel(String id, IModel<PostgresConfigBean> model) {
         super(id, model);
 
         setOutputMarkupId(true);
-        add(hostField = new TextField<>("pgHost", new PropertyModel<String>(model, "host"),
-                String.class));
-        hostField.setRequired(true);
-        add(portField = new TextField<>("pgPort", new PropertyModel<Integer>(model, "port"),
-                Integer.TYPE));
-        portField.add(new MinimumValidator<>(1025), new MaximumValidator<>(65535));
-        add(dbField = new TextField<>("pgDatabase", new PropertyModel<String>(model, "database"),
-                String.class));
-        dbField.setRequired(true);
-        add(schemaField = new TextField<>("pgSchema", new PropertyModel<String>(model, "schema"),
-                String.class));
-        add(usernameField = new TextField<>("pgUsername", new PropertyModel<String>(model,
-                "username"), String.class));
-        usernameField.setRequired(true);
-        add(passwordField = new PasswordTextField("pgPassword", new PropertyModel<String>(model,
-                "password")).setResetPassword(false));
-        passwordField.setType(String.class);
-        passwordField.setRequired(true);
+        hostPanel = new TextParamPanel("hostPanel", new PropertyModel<String>(model, "host"),
+                new ResourceModel("PostgresConfigFormPanel.host", "Host Name"), true);
+        add(hostPanel);
+        portPanel = new TextParamPanel("portPanel", new PropertyModel<Integer>(model, "port"),
+                new ResourceModel("PostgresConfigFormPanel.port", "Port"), false);
+        // set the type for the port, and validators
+        portPanel.getFormComponent().setType(Integer.TYPE).add(new MinimumValidator<>(1025),
+                new MaximumValidator<>(65535));
+        add(portPanel);
+        dbPanel = new TextParamPanel("dbPanel", new PropertyModel<String>(model, "database"),
+                new ResourceModel("PostgresConfigFormPanel.database", "Database Name"), true);
+        add(dbPanel);
+        schemaPanel = new TextParamPanel("schemaPanel", new PropertyModel<String>(model, "schema"),
+                new ResourceModel("PostgresConfigFormPanel.schema", "Schema Name"), false);
+        add(schemaPanel);
+        usernamePanel = new TextParamPanel("usernamePanel", new PropertyModel<String>(model,
+                "username"), new ResourceModel("PostgresConfigFormPanel.username",
+                "Username"), true);
+        add(usernamePanel);
+        passwordPanel = new PasswordParamPanel("passwordPanel", new PropertyModel<String>(model,
+                "password"), new ResourceModel("PostgresConfigFormPanel.password",
+                "Password"), true);
+        add(passwordPanel);
     }
 
     @Override
@@ -58,22 +64,22 @@ class PostgresConfigFormPanel extends FormComponentPanel<PostgresConfigBean> {
             bean = new PostgresConfigBean();
         }
         // populate the bean
-        String host = hostField.getConvertedInput().trim();
-        Integer port = portField.getConvertedInput();
-        String db = dbField.getConvertedInput().trim();
-        String schema = schemaField.getConvertedInput();
-        String username = usernameField.getConvertedInput().trim();
-        String password = passwordField.getConvertedInput().trim();
+        String host = hostPanel.getFormComponent().getConvertedInput().toString().trim();
+        Integer port = Integer.class.cast(portPanel.getFormComponent().getConvertedInput());
+        String db = dbPanel.getFormComponent().getConvertedInput().toString().trim();
+        Object schema = schemaPanel.getFormComponent().getConvertedInput();
+        String username = usernamePanel.getFormComponent().getConvertedInput().toString().trim();
+        String password = passwordPanel.getFormComponent().getConvertedInput();
 
         bean.setHost(host);
         bean.setPort(port);
         bean.setDatabase(db);
         bean.setUsername(username);
         bean.setPassword(password);
-        if (schema == null || schema.trim().isEmpty()) {
+        if (schema == null || schema.toString().trim().isEmpty()) {
             bean.setSchema(null);
         } else {
-            bean.setSchema(schema);
+            bean.setSchema(schema.toString().trim());
 
         }
 

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/PostgresConfigFormPanel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/PostgresConfigFormPanel.java
@@ -34,6 +34,7 @@ class PostgresConfigFormPanel extends FormComponentPanel<PostgresConfigBean> {
         setOutputMarkupId(true);
         hostPanel = new TextParamPanel("hostPanel", new PropertyModel<String>(model, "host"),
                 new ResourceModel("PostgresConfigFormPanel.host", "Host Name"), true);
+        hostPanel.getFormComponent().setType(String.class);
         add(hostPanel);
         portPanel = new TextParamPanel("portPanel", new PropertyModel<Integer>(model, "port"),
                 new ResourceModel("PostgresConfigFormPanel.port", "Port"), false);
@@ -43,26 +44,27 @@ class PostgresConfigFormPanel extends FormComponentPanel<PostgresConfigBean> {
         add(portPanel);
         dbPanel = new TextParamPanel("dbPanel", new PropertyModel<String>(model, "database"),
                 new ResourceModel("PostgresConfigFormPanel.database", "Database Name"), true);
+        dbPanel.getFormComponent().setType(String.class);
         add(dbPanel);
         schemaPanel = new TextParamPanel("schemaPanel", new PropertyModel<String>(model, "schema"),
                 new ResourceModel("PostgresConfigFormPanel.schema", "Schema Name"), false);
+        schemaPanel.getFormComponent().setType(String.class);
         add(schemaPanel);
         usernamePanel = new TextParamPanel("usernamePanel", new PropertyModel<String>(model,
                 "username"), new ResourceModel("PostgresConfigFormPanel.username",
                 "Username"), true);
+        usernamePanel.getFormComponent().setType(String.class);
         add(usernamePanel);
         passwordPanel = new PasswordParamPanel("passwordPanel", new PropertyModel<String>(model,
                 "password"), new ResourceModel("PostgresConfigFormPanel.password",
                 "Password"), true);
+        passwordPanel.getFormComponent().setType(String.class);
         add(passwordPanel);
     }
 
     @Override
     protected void convertInput() {
-        PostgresConfigBean bean = getModelObject();
-        if (bean == null) {
-            bean = new PostgresConfigBean();
-        }
+        PostgresConfigBean bean = new PostgresConfigBean();
         // populate the bean
         String host = hostPanel.getFormComponent().getConvertedInput().toString().trim();
         Integer port = Integer.class.cast(portPanel.getFormComponent().getConvertedInput());

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryEditFormPanel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryEditFormPanel.java
@@ -4,7 +4,6 @@
  */
 package org.geogig.geoserver.web.repository;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -157,10 +156,10 @@ public abstract class RepositoryEditFormPanel extends Panel {
 
     private void onSave(RepositoryInfo repoInfo, AjaxRequestTarget target) {
         RepositoryManager manager = RepositoryManager.get();
-        repoInfo = manager.save(repoInfo);
         // update remotes
         GeoGIG geogig;
         try {
+            repoInfo = manager.save(repoInfo);
             geogig = manager.getRepository(repoInfo.getId());
         } catch (Exception e) {
             form.error("Unable to connect to repository " + repoInfo.getLocation() +

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryImportFormPanel.html
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryImportFormPanel.html
@@ -1,0 +1,17 @@
+<html xmlns:wicket="http://wicket.apache.org/">
+  <head>
+    <title><wicket:message key="title">Repositories</wicket:message></title>
+  </head>
+  <body>
+  <wicket:panel>
+    <form wicket:id="repoForm">
+      <div wicket:id="repo"></div>
+      <div class="button-group selfclear">
+        <a href="#" wicket:id="import"><wicket:message key="import">Import</wicket:message></a>
+        <a href="#" wicket:id="cancel"><wicket:message key="cancel">Cancel</wicket:message></a>
+      </div>			
+      <div wicket:id="feedback"/>
+    </form>
+  </wicket:panel>
+</body>
+</html>

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryImportFormPanel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryImportFormPanel.java
@@ -1,0 +1,88 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geogig.geoserver.web.repository;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.AjaxLink;
+import org.apache.wicket.ajax.markup.html.form.AjaxSubmitLink;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.panel.FeedbackPanel;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.geogig.geoserver.config.RepositoryInfo;
+import org.geogig.geoserver.config.RepositoryManager;
+
+/**
+ * The main Wicket panel for importing an existing GeoGig repository. This panel is very similar to
+ * {@link RepositoryEditFormPanel}, but it is not concerned with repository remotes. Remotes of an
+ * imported GeoGig repository will be included with the repository import. Once imported, users can
+ * navigate to the Edit page to edit remotes.
+ */
+public abstract class RepositoryImportFormPanel extends Panel {
+
+    private static final long serialVersionUID = 1L;
+
+    private Form<RepositoryInfo> form;
+
+    public RepositoryImportFormPanel(String id) {
+        this(id, null);
+    }
+
+    public RepositoryImportFormPanel(String id, IModel<RepositoryInfo> repoInfo) {
+        super(id);
+
+        if (repoInfo == null) {
+            repoInfo = new Model<>(new RepositoryInfo());
+        }
+        setDefaultModel(repoInfo);
+
+        form = new Form<>("repoForm", repoInfo);
+        form.add(new RepositoryImportPanel("repo", repoInfo));
+        add(form);
+        FeedbackPanel feedback = new FeedbackPanel("feedback");
+        form.add(feedback);
+
+        form.add(new AjaxLink<Void>("cancel") {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public void onClick(AjaxRequestTarget target) {
+                cancelled(target);
+            }
+        });
+
+        form.add(new AjaxSubmitLink("import", form) {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            protected void onError(AjaxRequestTarget target, Form<?> form) {
+                super.onError(target, form);
+                target.addComponent(form);
+            }
+
+            @Override
+            protected void onSubmit(AjaxRequestTarget target, Form<?> form) {
+                try {
+                    RepositoryInfo repoInfo = (RepositoryInfo) form.getModelObject();
+                    onSave(repoInfo, target);
+                } catch (IllegalArgumentException e) {
+                    form.error(e.getMessage());
+                    target.addComponent(form);
+                }
+            }
+        });
+    }
+
+    private void onSave(RepositoryInfo repoInfo, AjaxRequestTarget target) {
+        RepositoryManager manager = RepositoryManager.get();
+        repoInfo = manager.save(repoInfo);
+        saved(repoInfo, target);
+    }
+
+    protected abstract void saved(RepositoryInfo info, AjaxRequestTarget target);
+
+    protected abstract void cancelled(AjaxRequestTarget target);
+}

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryImportPanel$RepoDirectoryComponent.html
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryImportPanel$RepoDirectoryComponent.html
@@ -1,0 +1,12 @@
+<html xmlns:wicket="http://wicket.apache.org/">
+  <body>
+  <wicket:panel>
+    <label wicket:id="repoLabel">bar</label>
+    <div wicket:id="wrapper">
+      <input class="text" wicket:id="repoDirectory" type="text"/>
+      <a href="#" wicket:id="chooser"><wicket:message key="browse">...</wicket:message></a>
+    </div>
+    <div wicket:id="dialog"></div>
+  </wicket:panel>
+</body>
+</html>

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryImportPanel.html
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryImportPanel.html
@@ -1,0 +1,17 @@
+<html xmlns:wicket="http://wicket.apache.org/">
+  <body>
+  <wicket:panel>
+    <fieldset>
+      <legend><span><wicket:message key="connectionParameters">Connection Parameters</wicket:message></span></legend>
+      <ul>
+        <li wicket:id="configChoicePanel">configChoicePanel</li>
+        <div wicket:id="settingsContainer">
+          <li wicket:id=repositoryNamePanel">repositoryNamePanel</li>
+          <li wicket:id="parentDirectoryPanel">parentDirectory</li>
+          <li wicket:id="pgPanel">pgPanel</li>
+        </div>
+      </ul>
+    </fieldset>
+  </wicket:panel>
+</body>
+</html>

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryImportPanel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryImportPanel.java
@@ -1,0 +1,301 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geogig.geoserver.web.repository;
+
+import static org.geogig.geoserver.config.RepositoryManager.isGeogigDirectory;
+
+import java.io.File;
+import java.io.Serializable;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
+import org.apache.wicket.ajax.markup.html.form.AjaxSubmitLink;
+import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.DropDownChoice;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.FormComponentPanel;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.html.form.validation.FormComponentFeedbackBorder;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.model.ResourceModel;
+import org.apache.wicket.validation.IValidatable;
+import org.apache.wicket.validation.IValidator;
+import org.apache.wicket.validation.ValidationError;
+import org.geogig.geoserver.config.ImportRepositoryFormBean;
+import org.geogig.geoserver.config.PostgresConfigBean;
+import org.geogig.geoserver.config.RepositoryInfo;
+import org.geogig.geoserver.config.RepositoryManager;
+import org.geogig.geoserver.model.DropDownModel;
+import org.geogig.geoserver.model.ImportRepositoryFormModel;
+import org.geogig.geoserver.util.PostgresConnectionErrorHandler;
+import org.geoserver.web.data.store.panel.DropDownChoiceParamPanel;
+import org.geoserver.web.data.store.panel.TextParamPanel;
+import org.locationtech.geogig.repository.RepositoryResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Wicket panel that holds the components for importing an existing GeoGig repository. This is
+ * very similar to {@link RepositoryEditPanel}, however there are some subtle differences. Since
+ * this panel is used for importing an existing repo, the validation checks are different. Also, the
+ * {@link DirectoryChooser} is configured to allow repository directories to be selected instead of
+ * just the parent directory. As such, the repository name is not separately selected. The
+ * differences also called for a slightly different way of wrapping the {@link RepositoryInfo} data
+ * bean with a different data model, {@link ImportRepositoryFormModel} and
+ * {@link ImportRepositoryFormBean}.
+ */
+public class RepositoryImportPanel extends FormComponentPanel<RepositoryInfo> {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryImportPanel.class);
+
+    private final TextParamPanel repoNamePanel;
+    private final DropDownChoiceParamPanel dropdownPanel;
+    private final RepoDirectoryComponent repoDirectoryComponent;
+    private final PostgresConfigFormPanel pgPanel;
+    private final WebMarkupContainer settingsPanel;
+
+    public RepositoryImportPanel(String id, IModel<RepositoryInfo> model) {
+        super(id, model);
+
+        setOutputMarkupId(true);
+
+        // build the backing form model
+        ImportRepositoryFormModel formModel = new ImportRepositoryFormModel(model);
+        // add the dropdown to switch between configurations
+        dropdownPanel = new DropDownChoiceParamPanel("configChoicePanel", new DropDownModel(model),
+                new ResourceModel("RepositoryImportPanel.repositoryType",
+                        "Repository Type"), DropDownModel.CONFIG_LIST, true);
+        final DropDownChoice<Serializable> dropDownChoice = dropdownPanel.getFormComponent();
+        dropDownChoice.add(new AjaxFormComponentUpdatingBehavior("onChange") {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            protected void onUpdate(AjaxRequestTarget target) {
+                final String value = dropDownChoice.getModelObject().toString();
+                repoDirectoryComponent.setVisible(DropDownModel.DIRECTORY_CONFIG.equals(value));
+                pgPanel.setVisible(DropDownModel.PG_CONFIG.equals(value));
+                repoNamePanel.setVisible(DropDownModel.PG_CONFIG.equals(value));
+                target.addComponent(settingsPanel);
+            }
+        });
+        add(dropdownPanel);
+
+        settingsPanel = new WebMarkupContainer("settingsContainer");
+        settingsPanel.setOutputMarkupId(true);
+        add(settingsPanel);
+
+        repoNamePanel = new TextParamPanel("repositoryNamePanel", new PropertyModel(formModel,
+                "repoName"),
+                new ResourceModel("RepositoryImportPanel.repositoryName",
+                        "Repository Name"), true);
+        repoNamePanel.setOutputMarkupId(true);
+        repoNamePanel.getFormComponent().setOutputMarkupId(true);
+        repoNamePanel.setVisible(DropDownModel.PG_CONFIG.equals(dropDownChoice.getModelObject()
+                .toString()));
+        settingsPanel.add(repoNamePanel);
+
+        pgPanel = new PostgresConfigFormPanel("pgPanel", new PropertyModel<PostgresConfigBean>(
+                formModel, "pgBean"));
+        pgPanel.setVisible(DropDownModel.PG_CONFIG
+                .equals(dropDownChoice.getModelObject().toString()));
+        settingsPanel.add(pgPanel);
+
+        repoDirectoryComponent = new RepoDirectoryComponent("parentDirectoryPanel", formModel);
+        repoDirectoryComponent.setOutputMarkupId(true);
+        repoDirectoryComponent
+                .setVisible(DropDownModel.DIRECTORY_CONFIG.equals(dropDownChoice.getModelObject()
+                        .toString()));
+        settingsPanel.add(repoDirectoryComponent);
+
+        add(new IValidator<RepositoryInfo>() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public void validate(IValidatable<RepositoryInfo> validatable) {
+                ValidationError error = new ValidationError();
+                RepositoryInfo repo = validatable.getValue();
+                final URI location = repo.getLocation();
+                // look for already configured repos
+                List<RepositoryInfo> existingRepos = RepositoryManager.get().getAll();
+                for (RepositoryInfo configuredRepo : existingRepos) {
+                    if (configuredRepo.getLocation().equals(location)) {
+                        error.addMessageKey("errRepositoryAlreadyConfigured");
+                        // quit looking
+                        break;
+                    }
+                }
+                if (error.getKeys().isEmpty()) {
+                    final RepositoryResolver resolver = RepositoryResolver.lookup(location);
+                    final String scheme = location.getScheme();
+                    if ("file".equals(scheme)) {
+                        File repoDir = new File(location);
+                        if (!repoDir.exists() || !repoDir.isDirectory()) {
+                            error.addMessageKey("errRepositoryDirectoryDoesntExist");
+                        }
+                        if (!isGeogigDirectory(repoDir)) {
+                            error.addMessageKey("notAGeogigRepository");
+                        }
+                    } else if ("postgresql".equals(scheme)) {
+                        try {
+                            if (!resolver.repoExists(location)) {
+                                error.addMessageKey("errRepositoryDoesntExist");
+                            }
+                        } catch (Exception ex) {
+                            // likely failed to connect
+                            LOGGER.error("Failed to connect to PostgreSQL database", ex);
+                            error.addMessageKey("errCannotConnectToDatabase");
+                            // find root cause
+                            error.setVariable("message", PostgresConnectionErrorHandler.getMessage(
+                                    ex));
+                        }
+                    }
+                }
+                if (!error.getKeys().isEmpty()) {
+                    validatable.error(error);
+                }
+            }
+        });
+    }
+
+    @Override
+    protected void convertInput() {
+        RepositoryInfo repoInfo = getModelObject();
+        final String repoTypeChoice = dropdownPanel.getFormComponent().getConvertedInput()
+                .toString();
+        if (null != repoTypeChoice) {
+            switch (repoTypeChoice) {
+                case DropDownModel.PG_CONFIG:
+                    // PG config used
+                    PostgresConfigBean bean = pgPanel.getConvertedInput();
+                    // build a URI out of the config
+                    URI uri = bean.buildUriForRepo(repoNamePanel.getFormComponent()
+                            .getConvertedInput().toString().trim());
+                    repoInfo.setLocation(uri);
+                    break;
+                case DropDownModel.DIRECTORY_CONFIG:
+                    // local directory used
+                    ImportRepositoryFormBean formBean = repoDirectoryComponent.getConvertedInput();
+                    Path uriPath = Paths.get(formBean.getRepoDirectory());
+                    repoInfo.setLocation(uriPath.toUri());
+                    break;
+                default:
+                    throw new IllegalStateException(
+                            String.format("Unknown repositry type '%s', expected one of %s, %s",
+                                    repoTypeChoice, DropDownModel.PG_CONFIG,
+                                    DropDownModel.DIRECTORY_CONFIG));
+            }
+        }
+        setConvertedInput(repoInfo);
+    }
+
+    static class RepoDirectoryComponent extends FormComponentPanel<ImportRepositoryFormBean> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final TextField<String> repoDirectoryField;
+        private final ModalWindow dialog;
+
+        RepoDirectoryComponent(String id, IModel<ImportRepositoryFormBean> model) {
+            super(id, model);
+
+            dialog = new ModalWindow("dialog");
+            add(dialog);
+
+            repoDirectoryField = new TextField<>("repoDirectory", new PropertyModel<String>(model,
+                    "repoDirectory"));
+            repoDirectoryField.setRequired(true);
+            repoDirectoryField.setOutputMarkupId(true);
+
+            Label directoryLabel = new Label("repoLabel", new ResourceModel(
+                    "RepositoryImportPanel.directoryLabel",
+                    "Parent Directory") {
+
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public String getObject() {
+                    String value = super.getObject();
+                    return value + " *";
+                }
+            }.getObject());
+            add(directoryLabel);
+
+            FormComponentFeedbackBorder feedback = new FormComponentFeedbackBorder("wrapper");
+            feedback.add(repoDirectoryField);
+            feedback.add(createChooserButton());
+            add(feedback);
+        }
+
+        @Override
+        protected void convertInput() {
+            ImportRepositoryFormBean bean = new ImportRepositoryFormBean();
+            String repoDir = repoDirectoryField.getConvertedInput();
+            bean.setRepoDirectory(repoDir);
+            setConvertedInput(bean);
+        }
+
+        private Component createChooserButton() {
+            return new AjaxSubmitLink("chooser") {
+
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public boolean getDefaultFormProcessing() {
+                    return false;
+                }
+
+                @Override
+                protected void onSubmit(AjaxRequestTarget target, Form form) {
+                    File repoDirFile = null;
+                    repoDirectoryField.processInput();
+                    String repoDir = repoDirectoryField.getConvertedInput();
+                    if (repoDir != null && !repoDir.trim().isEmpty()) {
+                        repoDirFile = new File(repoDir);
+                    }
+                    DirectoryChooser chooser = new DirectoryChooser(dialog.getContentId(),
+                            new Model<>(repoDirFile), true) {
+
+                        private static final long serialVersionUID = 1L;
+
+                        @Override
+                        protected void geogigDirectoryClicked(File file, AjaxRequestTarget target) {
+                            repoDirectoryField.clearInput();
+                            repoDirectoryField.setModelObject(file.getAbsolutePath());
+                            target.addComponent(repoDirectoryField);
+                            dialog.close(target);
+                        }
+
+                        @Override
+                        protected void directorySelected(File file, AjaxRequestTarget target) {
+                            repoDirectoryField.clearInput();
+                            repoDirectoryField.setModelObject(file.getAbsolutePath());
+                            target.addComponent(repoDirectoryField);
+                            dialog.close(target);
+                        }
+
+                    };
+                    chooser.setFileTableHeight(null);
+                    dialog.setContent(chooser);
+                    dialog.setTitle(new ResourceModel(
+                            "GeoGigDirectoryFormComponent.chooser.chooseParentTile"));
+                    dialog.show(target);
+                }
+
+            };
+        }
+    }
+}

--- a/src/community/geogig/src/main/resources/GeoServerApplication.properties
+++ b/src/community/geogig/src/main/resources/GeoServerApplication.properties
@@ -68,6 +68,8 @@ RepositoryEditPanel.errParentDoesntExist=Parent directory does not exist or is n
 RepositoryEditPanel.errDirectoryExists=The specified directory already exists in the file system
 RepositoryEditPanel.errParentReadOnly=Parent directory is not writable
 RepositoryEditPanel.notAGeogigRepository=The specified directory is not a GeoGig repository
+RepositoryEditPanel.errRepositoryExists=The specified repository already exists
+RepositoryEditPanel.errCannotConnectToDatabase=Unable to connect to the database, please check input values: [${message}]
 
 GeoGigDirectoryFormComponent.directory=Parent directory
 GeoGigDirectoryFormComponent.browse=Browse...
@@ -105,3 +107,18 @@ PostgresConfigFormPanel.database=Database Name
 PostgresConfigFormPanel.schema=Schema Name
 PostgresConfigFormPanel.username=Username
 PostgresConfigFormPanel.password=Password
+
+RepositoryImportPage.title=Repository configuration
+RepositoryImportPage.description=Import a GeoGig repository
+RepositoryImportPage.name=Repository name
+
+RepositoryImportPanel.directoryLabel=Repository Directory
+RepositoryImportPanel.browse=Browse...
+RepositoryImportPanel.errRepositoryDoesntExist=The specified repository or schema does not exist
+RepositoryImportPanel.errRepositoryDirectoryDoesntExist=The specified repository directory does not exist
+RepositoryImportPanel.notAGeogigRepository=The specified directory is not a GeoGig repository
+RepositoryImportPanel.errRepositoryAlreadyConfigured=The specified repository is already configured
+RepositoryImportPanel.errCannotConnectToDatabase=Unable to connect to the database, please check input values: [${message}]
+
+RepositoryImportFormPanel.import=Import
+RepositoryImportFormPanel.cancel=Cancel

--- a/src/community/geogig/src/main/resources/GeoServerApplication.properties
+++ b/src/community/geogig/src/main/resources/GeoServerApplication.properties
@@ -68,7 +68,6 @@ RepositoryEditPanel.errParentDoesntExist=Parent directory does not exist or is n
 RepositoryEditPanel.errDirectoryExists=The specified directory already exists in the file system
 RepositoryEditPanel.errParentReadOnly=Parent directory is not writable
 RepositoryEditPanel.notAGeogigRepository=The specified directory is not a GeoGig repository
-RepositoryEditPanel.configChoice=Repository Type
 
 GeoGigDirectoryFormComponent.directory=Parent directory
 GeoGigDirectoryFormComponent.browse=Browse...
@@ -97,11 +96,12 @@ SecurityLogsPanel.th.repository=Repository
 SecurityLogsPanel.th.user=User
 SecurityLogsPanel.th.message=Message
 
-GeoGigRepositoryInfoFormComponent.name=Repository name
+GeoGigRepositoryInfoFormComponent.repositoryName=Repository Name
+GeoGigRepositoryInfoFormComponent.configChoice=Repository Type
 
-PostgresConfigFormPanel.host=PostgreSQL Host Name
-PostgresConfigFormPanel.port=PostgreSQL Port
-PostgresConfigFormPanel.database=PostgreSQL Database Name
-PostgresConfigFormPanel.schema=PostgreSQL Schema Name
-PostgresConfigFormPanel.username=PostgreSQL Username
-PostgresConfigFormPanel.password=PostgreSQL Password
+PostgresConfigFormPanel.host=Host Name
+PostgresConfigFormPanel.port=Port
+PostgresConfigFormPanel.database=Database Name
+PostgresConfigFormPanel.schema=Schema Name
+PostgresConfigFormPanel.username=Username
+PostgresConfigFormPanel.password=Password


### PR DESCRIPTION
- Change repository location config to be a URI instead of a String
- Add extra UI component configuration to support PG URIs
- Refactor the models to transform data between UI fields and a GeoGig repository
- Modify some error handling when PostgreSQL backed repositories are not reachable during edit.
- Fix REST interface for GeoGig plugin
